### PR TITLE
Fix node app erroring on startup

### DIFF
--- a/bin/prestart
+++ b/bin/prestart
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script checks for the existence of the react-loadable.json file which is required by the
+# React Router middleware (src/server/middleware/react-router) so that react-loadable knows which bundles
+# to send in the initial payload. If this file doesn't exist the node app fails.
+
+if [ ! -e dist/react-loadable.json ]
+then
+  echo "Running Webpack to generate react-loadable.json. See bin/prestart for details"
+  BABEL_ENV=browser ./node_modules/.bin/webpack
+fi

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Experimenting with React Router 4 and how it can work with Redux",
   "main": "server.js",
   "scripts": {
+    "prestart": "bin/prestart",
+    "start": "npm-run-all -p start:*",
     "start:client": "BABEL_ENV=browser ./node_modules/.bin/webpack --watch",
-    "start:server": "BABEL_ENV=node nodemon --exec babel-node ./src/server",
-    "start": "npm-run-all -p start:*"
+    "start:server": "BABEL_ENV=node nodemon --exec babel-node ./src/server"
   },
   "author": "James Filtness",
   "dependencies": {


### PR DESCRIPTION
When the node app started up it was looking for the react-loadable.json file. Because the node app and webpack are run in parrallel the json file had not been generated in time to be ready for the node app. This commit ensures that the json is in place before the node app starts. It's a workaround but currently I don't have any better ideas...